### PR TITLE
preprocessing: keep source_container[source_key] on rewrite

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,5 +5,8 @@ Changelog
 1.0a1 (unreleased)
 ------------------
 
+- Keep source on rewrite 
+  [ksuess]
+
 - Initial release.
   [jensens]

--- a/src/collective/elastic/ingest/preprocessing.py
+++ b/src/collective/elastic/ingest/preprocessing.py
@@ -73,7 +73,6 @@ def action_rewrite(content, full_schema, config):
             raise ValueError("Source {0} not in content.".format(config['source']))
         return
     target_container[target_key] = source_container[source_key]
-    del source_container[source_key]
 
 ACTION_FUNCTIONS["rewrite"] = action_rewrite
 


### PR DESCRIPTION
preprocessing: do not delete source on rewrite

I would like to keep for example @type but also add portal_type:


```
  {
    "match": {
      "type": "always"
    },
    "action": "rewrite",
    "configuration": {
      "source": "@type",
      "target": "portal_type"
    }
  },
```

@agitator, @jensens do you think removing 

`del source_container[source_key]`

hurts?

Do you think there is another way to have both @type and the additional portal_type? Then I would close this PR.
